### PR TITLE
Add capability for Parallel reverse order

### DIFF
--- a/lib/dagwood/dependency_graph.rb
+++ b/lib/dagwood/dependency_graph.rb
@@ -24,6 +24,10 @@ module Dagwood
       @reverse_order ||= order.reverse
     end
 
+    def parallel_reverse_order
+      parallel_order.reverse
+    end
+
     # Similar to #order, except this will group items that
     # have the same "priority", thus indicating they can be done
     # in parallel.

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -76,6 +76,13 @@ describe Dagwood::DependencyGraph do
     end
   end
 
+  describe '#parallel_reverse_order' do
+    it 'returns reverse order for the parallel_orders' do
+      graph = Dagwood::DependencyGraph.new(item1: %i[], item2: %i[item1], item3: %i[], item4: %i[item3 item5], item5: %i[item3 item6], item6: %i[item1])
+      expect(graph.parallel_reverse_order).to eql [%i[item4], %i[item5], %i[item2 item6], %i[item1 item3]]
+    end
+  end
+
   describe '#subgraph' do
     it 'includes only given node if it has no dependencies' do
       graph = Dagwood::DependencyGraph.new(item1: %i[])


### PR DESCRIPTION
Add the ability for Dagwood to do reverse parallel order.

I did some testing manually so let's take an example of the below dependency tree:

```
{
        'A' => %w[G],
        'B' => %w[D C H I K M N O R S],
        'C' => %w[A D G J K Q],
        'D' => %w[A F G J O],
        'E' => %w[A F I J],
        'F' => %w[],
        'G' => %w[],
        'H' => %w[A F G I J N O S],
        'I' => %w[A G S],
        'J' => %w[],
        'K' => %w[A F G I J R S],
        'L' => %w[],
        'M' => %w[A F G I J O],
        'N' => %w[A F G I J M O],
        'O' => %w[A],
        'P' => %w[],
        'Q' => %w[A F G I J P],
        'R' => %w[A G H I N Q S],
        'S' => %w[],
        'T' => %w[A]
      }
```

