### PR TITLE
Update set-output calls in GHA

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -23,8 +23,8 @@ jobs:
       run: |
         version_file=$(find ./lib -name version.rb)
         version=$(grep VERSION $version_file |cut -f 2 -d= |tr -d \'|tr -d [:space:])
-        echo ::set-output name=version::$version
-        echo ::set-output name=version_tag::v$version
+        echo version=$version >> $GITHUB_OUTPUT
+        echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
       uses: tvdias/github-tagger@v0.0.1


### PR DESCRIPTION
`set-output` is set to be deprecated in 2023. This change migrates calls of set-output to use the GITHUB_OUTPUT env file instead as per GH's recommendation.