### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,61 +11,61 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@main
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
-    - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
+        with:
+          ruby-version: 2.7
 
-    - name: Get version
-      id: get_version
-      run: |
-        version_file=$(find ./lib -name version.rb)
-        version=$(grep VERSION $version_file |cut -f 2 -d= |tr -d \'|tr -d [:space:])
-        echo version=$version >> $GITHUB_OUTPUT
-        echo version_tag=v$version >> $GITHUB_OUTPUT
+      - name: Get version
+        id: get_version
+        run: |
+          version_file=$(find ./lib -name version.rb)
+          version=$(grep VERSION $version_file |cut -f 2 -d= |tr -d \'|tr -d [:space:])
+          echo version=$version >> $GITHUB_OUTPUT
+          echo version_tag=v$version >> $GITHUB_OUTPUT
 
-    - name: Tag commit
-      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        tag: "${{steps.get_version.outputs.version_tag}}"
+      - name: Tag commit
+        uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{steps.get_version.outputs.version_tag}}"
 
-    - name: Upload to Rubygems
-      env:
-        RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-      run: |
-        set +e
-        mkdir -p ~/.gem
-        touch ~/.gem/credentials
-        chmod 600 ~/.gem/credentials
-        echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
+      - name: Upload to Rubygems
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          set +e
+          mkdir -p ~/.gem
+          touch ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+          echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
 
-        gemspec=$(ls *gemspec* | head -1)
-        gem build $gemspec
-        gem_name=$(ls -t *.gem | head -1)
-        output=$(gem push *.gem)
+          gemspec=$(ls *gemspec* | head -1)
+          gem build $gemspec
+          gem_name=$(ls -t *.gem | head -1)
+          output=$(gem push *.gem)
 
-        if [[ $output != *"Successfully"* ]]; then
-          echo "Error uploading to Rubygems: $output"
-          rm -f ~/.gem/credentials
-          exit 1
-        else
-          echo "Successfully uploaded to Rubygems: $output"
-          rm -f ~/.gem/credentials
-        fi
+          if [[ $output != *"Successfully"* ]]; then
+            echo "Error uploading to Rubygems: $output"
+            rm -f ~/.gem/credentials
+            exit 1
+          else
+            echo "Successfully uploaded to Rubygems: $output"
+            rm -f ~/.gem/credentials
+          fi
 
-    - name: Extract from changelog
-      id: extract_changes
-      run: |
-        # Must use a temporary file or it loses the formatting
-        VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
+      - name: Extract from changelog
+        id: extract_changes
+        run: |
+          # Must use a temporary file or it loses the formatting
+          VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
 
-    - name: Create Release
-      uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
-      with:
-        tag: ${{steps.get_version.outputs.version_tag}}
-        artifacts: "*.gem, CHANGELOG.md"
-        bodyFile: "REL-BODY.md"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+        with:
+          tag: ${{steps.get_version.outputs.version_tag}}
+          artifacts: "*.gem, CHANGELOG.md"
+          bodyFile: "REL-BODY.md"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
