### PR TITLE
chore: update CODEOWNERS team ref to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence, members of
 # @rewindio/codeowners will be requested for review when someone
 # opens a pull request.
-*       @rewindio/developers
+*       @rewind-community/developers


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community` as part of the OSS-repo classification cleanup (terraform side: rewindio/terraform-rewindio-github#367). The existing `@rewindio/developers` reference is silently dropped by GitHub because team references can't cross organizations — swapping to `@rewind-community/developers` (same team name in the new org) restores reviewer assignment.

## Related PRs

- rewindio/terraform-rewindio-github#367

## Testing Performed

Single-line CODEOWNERS update — no code paths affected. GitHub will pick up the new team reference on next PR.

[DEVOPS-4349]: https://rewind.atlassian.net/browse/DEVOPS-4349